### PR TITLE
feature/busco

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,13 @@ __pycache__/
 *.swp
 *~
 
+# --- Other stuff
+.cache/
+.config/
+.keras/
+.parallel/
+.vscode/
+.env
+.venv/
+busco_lineages/
+logs/

--- a/config/control_panel.yaml
+++ b/config/control_panel.yaml
@@ -45,6 +45,9 @@ DB_FOLDER: "auto"
 # Run gene completeness analysis
 RUN_COMPL: on
 
+# Use BUSCO instead of COMPLEASM
+PREFER_BUSCO: on
+
 # BUSCO lineage to use
 ## Options: "auto" (searches for best matching lineage in addition to eukaryota, but may fail!), 
 ## or specific lineage name (e.g., eukaryota, primates, insecta, fungi, etc)

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -314,6 +314,10 @@ if missing:
 out_folder = Path(config["OUT_FOLDER"]) / "GEP2_results"
 out_folder.mkdir(parents=True, exist_ok=True)
 
+# ----- BUSCO-SWITCH: -----
+RUN_COMPL = _as_bool(config.get("RUN_COMPL", True))
+PREFER_BUSCO = _as_bool(config.get("PREFER_BUSCO", False))
+
 # Now set the missing input placeholder
 _MISSING_IN = os.path.join(
     config["OUT_FOLDER"], "GEP2_results", ".missing_input_placeholder_DO_NOT_CREATE"
@@ -1733,13 +1737,14 @@ def _get_unique_reads_for_species(species, read_type):
 # -------------------------------------------------------------------------------
 
 def get_asm_stats_results():
-    """Get expected assembly stats outputs, respecting RUN_COMPL flag"""
+    """Get expected assembly stats outputs, respecting RUN_COMPL and PREFER_BUSCO flags"""
     expected_files = []
     
     if not samples_config or "sp_name" not in samples_config:
         return expected_files
     
-    run_compl = _as_bool(config.get("RUN_COMPL", True))
+    run_compl = RUN_COMPL
+    use_busco = PREFER_BUSCO
     
     for species, species_data in samples_config["sp_name"].items():
         if not species_data or "asm_id" not in species_data:
@@ -1759,15 +1764,22 @@ def get_asm_stats_results():
                 asm_basename = get_assembly_basename(asm_path)
                 base_path = os.path.join(out_folder, species, assembly)
                 
+                # always include gfastats
                 expected_files.append(
                     os.path.join(base_path, "gfastats", f"{asm_basename}_stats.txt")
                 )
                 
                 if run_compl:
-                    expected_files.extend([
-                        os.path.join(base_path, "compleasm", asm_basename, f"{asm_basename}_summary.txt"),
-                        os.path.join(base_path, "compleasm", asm_basename, f"{asm_basename}_results.tar.gz")
-                    ])
+                    if use_busco:
+                        expected_files.extend([
+                            os.path.join(base_path, "busco", asm_basename, f"{asm_basename}_summary.txt"),
+                            os.path.join(base_path, "busco", asm_basename, f"{asm_basename}_results.tar.gz")
+                        ])
+                    else:
+                        expected_files.extend([
+                            os.path.join(base_path, "compleasm", asm_basename, f"{asm_basename}_summary.txt"),
+                            os.path.join(base_path, "compleasm", asm_basename, f"{asm_basename}_results.tar.gz")
+                        ])
     
     return expected_files
 

--- a/workflow/rules/A_asm_stats.smk
+++ b/workflow/rules/A_asm_stats.smk
@@ -171,3 +171,103 @@ rule A02_compleasm:
         
         echo "[GEP2] compleasm completed successfully"
         """
+
+rule A02_busco:
+    """Assess assembly completeness with BUSCO"""
+    input:
+        asm = get_assembly_input
+    output:
+        summary = os.path.join(
+            config["OUT_FOLDER"], "GEP2_results", "{species}", "{assembly}",
+            "busco", "{asm_basename}", "{asm_basename}_summary.txt"
+        ),
+        archive = os.path.join(
+            config["OUT_FOLDER"], "GEP2_results", "{species}", "{assembly}",
+            "busco", "{asm_basename}", "{asm_basename}_results.tar.gz"
+        )
+    params:
+        outdir = lambda w: os.path.join(
+            config["OUT_FOLDER"], "GEP2_results", w.species, w.assembly,
+            "busco", w.asm_basename
+        ),
+        lineage = "eukaryota_odb12",
+        db_dir = BUSCO_DB_DIR
+    threads: cpu_func("compleasm")
+    resources:
+        mem_mb = mem_func("compleasm"),
+        runtime = time_func("compleasm")
+    container: CONTAINERS["gep2_base"]
+    log:
+        os.path.join(
+            config["OUT_FOLDER"], "GEP2_results", "{species}", "{assembly}",
+            "logs", "A02_busco_{asm_basename}.log"
+        )
+    benchmark:
+        os.path.join(
+            config["OUT_FOLDER"], "GEP2_results", "{species}", "{assembly}",
+            "logs", "A02_busco_{asm_basename}_benchmark.txt"
+        )
+    shell:
+        r'''
+        set -euo pipefail
+        mkdir -p "{params.outdir}" "$(dirname {log})"
+        exec > "{log}" 2>&1
+
+       echo "[GEP2] Running BUSCO on {input.asm}"
+        # temp workspace
+        BASE="${{GEP2_TMP:-$TMPDIR}}"
+        mkdir -p "$BASE" 2>/dev/null || BASE="$TMPDIR"
+
+        WORKDIR="$(mktemp -d "$BASE/GEP2_busco_{wildcards.species}_{wildcards.asm_basename}_XXXXXX")"
+
+        cd "$WORKDIR"
+
+        # Run BUSCO
+        busco \
+            -i "{input.asm}" \
+            -o "{wildcards.asm_basename}" \
+            -m genome \
+            -c {threads} \
+            --auto-lineage-euk \
+            --out_path "$WORKDIR" \
+            --download_path "{params.db_dir}"
+
+        echo "[GEP2] BUSCO run finished"
+
+        RUN_DIR="$WORKDIR/{wildcards.asm_basename}"
+
+        # =========================
+        # HANDLE SUMMARY
+        # =========================
+        SUMMARY_FILE=$(find "$RUN_DIR" -maxdepth 1 -name "short_summary*.txt" | head -1)
+
+        if [ -n "$SUMMARY_FILE" ]; then
+            mkdir -p "$(dirname {output.summary})"
+            cp "$SUMMARY_FILE" "{output.summary}"
+        else
+            echo "[GEP2] WARNING: No BUSCO summary found"
+            touch "{output.summary}"
+        fi
+
+        # =========================
+        # ARCHIVE RESULTS
+        # =========================
+        mkdir -p "$(dirname {output.archive})"
+        TB="{output.archive}"
+
+        cd "$RUN_DIR"
+
+        tar -czf "$TB" .
+
+        # validate archive
+        gzip -t "$TB"
+        tar -tzf "$TB" >/dev/null
+
+        echo "[GEP2] Archive created: $TB"
+
+        # cleanup
+        cd /
+        rm -rf "$WORKDIR"
+
+        echo "[GEP2] BUSCO completed successfully"
+        '''


### PR DESCRIPTION
add BUSCO as an alternative to compleasm for gene completeness analysis.

- Added rule A02_busco in A_asm_stats.smk-File
- Added PREFER_BUSCO config flag in Snakefile and control_panel.yaml
- RUN_COMPL and PREFER_BUSCO now read as global constants
- changed collector-logic of get_asm_stats_results() in Snakefile